### PR TITLE
CatalogueSearchPanel - Metadata popup window in IE doesn't show scrollbars

### DIFF
--- a/src/script/widgets/CatalogueSearchPanel.js
+++ b/src/script/widgets/CatalogueSearchPanel.js
@@ -388,7 +388,7 @@ gxp.CatalogueSearchPanel = Ext.extend(Ext.Panel, {
                                     var urlTemplate = this.sources[this.selectedSource].fullMetadataUrlTpl;
                                     if (urlTemplate) {
                                         var url = urlTemplate.apply({id: id});
-                                        window.open(url, "MDWindow", "width=800, height=600");
+                                        window.open(url, "MDWindow", "width=800, height=600, scrollbars=1, resizable=1");
                                     }
                                 },
                                 scope: this


### PR DESCRIPTION
Metadata popup window in IE doesn't contain scrollbars by default, also the window cannot be resized so metadata can't be seen properly.
